### PR TITLE
Separate tests in SettingTestCase

### DIFF
--- a/tests/test_appsettings.py
+++ b/tests/test_appsettings.py
@@ -10,15 +10,19 @@ import appsettings
 
 
 def imported_object():
-    return "tests.test_appsettings.SettingTestCase._imported_object2"
+    return "tests.test_appsettings.ImportedClass._imported_object2"
 
 
-class SettingTestCase(SimpleTestCase):
-    NOT_A_CALLABLE = {}  # type: dict
+class ImportedClass:
+    """Mixin for tests."""
 
     @staticmethod
     def _imported_object2():
         return "nothing"
+
+
+class SettingTestCase(SimpleTestCase):
+    NOT_A_CALLABLE = {}  # type: dict
 
     def setUp(self):
         self.message_required = "%s setting is required and"
@@ -64,8 +68,9 @@ class SettingTestCase(SimpleTestCase):
 
         setting.parent_setting = appsettings.NestedDictSetting(settings={}, name="parent_setting")
         with override_settings(PARENT_SETTING={}):
-            with pytest.raises(ImproperlyConfigured,
-                               match=self.message_missing_item % setting.parent_setting.full_name):
+            with pytest.raises(
+                ImproperlyConfigured, match=self.message_missing_item % setting.parent_setting.full_name
+            ):
                 assert setting.value
 
     def test_setting_transform(self):
@@ -103,8 +108,9 @@ class SettingTestCase(SimpleTestCase):
         setting = appsettings.Setting(name="INQUISITOR", validators=(validator,))
 
         with self.settings(INQUISITOR=mock.sentinel.lister):
-            with pytest.raises(ImproperlyConfigured,
-                               match="Setting INQUISITOR has an invalid value:.*You're not worthy!"):
+            with pytest.raises(
+                ImproperlyConfigured, match="Setting INQUISITOR has an invalid value:.*You're not worthy!"
+            ):
                 setting.check()
 
         assert validator.mock_calls == [mock.call(mock.sentinel.lister)]
@@ -118,8 +124,9 @@ class SettingTestCase(SimpleTestCase):
         setting = TestSetting(name="INQUISITOR")
 
         with self.settings(INQUISITOR=mock.sentinel.lister):
-            with pytest.raises(ImproperlyConfigured,
-                               match="Setting INQUISITOR has an invalid value:.*You're not worthy!"):
+            with pytest.raises(
+                ImproperlyConfigured, match="Setting INQUISITOR has an invalid value:.*You're not worthy!"
+            ):
                 setting.check()
 
     def test_setting_raw_value(self):
@@ -148,49 +155,234 @@ class SettingTestCase(SimpleTestCase):
             setting.check()
             assert setting.raw_value == "value"
 
+    @mock.patch.dict(os.environ, {"PREFERENCE_SETTING": '"__ENV__"'})
+    def test_preference_of_environ_values(self):
+        setting = appsettings.Setting(name="preference_setting")
+        with override_settings(PREFERENCE_SETTING="__OVER__"):
+            setting.check()
+            assert setting.value == "__ENV__"
+
+    @mock.patch.dict(os.environ, {"SETTING": '{"key": ["v", "a", "l"]}'})
+    def test_json_from_environ_value(self):
+        setting = appsettings.Setting(name="setting")
+        setting.check()
+        assert setting.value == {"key": ["v", "a", "l"]}
+
+
+class BooleanSettingTestCase(SimpleTestCase):
+    """BooleanSetting tests."""
+
     def test_boolean_setting(self):
         setting = appsettings.BooleanSetting()
         assert setting.value is True
+
+    @mock.patch.dict(os.environ, {"SETTING": "true"})
+    def test_json_boolean_setting_from_environ_true_value(self):
+        setting = appsettings.BooleanSetting(name="setting")
+        setting.check()
+        assert setting.value is True
+
+    @mock.patch.dict(os.environ, {"BOOL_LOWER": "true", "BOOL_UPPER": "TRUE", "BOOL_NUM": "1", "BOOL_WORD": "yes"})
+    def test_string_boolean_setting_from_environ_true_value(self):
+        bool_lower = appsettings.BooleanSetting(name="bool_lower")
+        bool_lower.check()
+        assert bool_lower.value is True
+
+        bool_upper = appsettings.BooleanSetting(name="bool_upper")
+        bool_upper.check()
+        assert bool_upper.value is True
+
+        bool_num = appsettings.BooleanSetting(name="bool_num")
+        bool_num.check()
+        assert bool_num.value is True
+
+        bool_word = appsettings.BooleanSetting(name="bool_word")
+        bool_word.check()
+        assert bool_word.value is True
+
+    @mock.patch.dict(os.environ, {"BOOL_LOWER": "false", "BOOL_UPPER": "FALSE", "BOOL_NUM": "0", "BOOL_WORD": "no"})
+    def test_string_boolean_setting_from_environ_false_value(self):
+        bool_lower = appsettings.BooleanSetting(name="bool_lower")
+        bool_lower.check()
+        assert bool_lower.value is False
+
+        bool_upper = appsettings.BooleanSetting(name="bool_upper")
+        bool_upper.check()
+        assert bool_upper.value is False
+
+        bool_num = appsettings.BooleanSetting(name="bool_num")
+        bool_num.check()
+        assert bool_num.value is False
+
+        bool_word = appsettings.BooleanSetting(name="bool_word")
+        bool_word.check()
+        assert bool_word.value is False
+
+    @mock.patch.dict(os.environ, {"BOOL_SETTING": "invalid"})
+    def test_string_boolean_setting_from_environ_invalid_value(self):
+        bool_setting = appsettings.BooleanSetting(name="bool_setting")
+        with pytest.raises(ValueError, match="Invalid boolean setting BOOL_SETTING"):
+            bool_setting.check()
+
+
+class IntegerSettingTestCase(SimpleTestCase):
+    """IntegerSetting tests."""
 
     def test_integer_setting(self):
         setting = appsettings.IntegerSetting()
         assert setting.value == 0
 
+    @mock.patch.dict(os.environ, {"SETTING": "123"})
+    def test_integer_setting_from_environ_value(self):
+        setting = appsettings.IntegerSetting(name="setting")
+        setting.check()
+        assert setting.value == 123
+        assert type(setting.value) is int
+
+
+class PositiveIntegerSettingTestCase(SimpleTestCase):
+    """PositiveIntegerSetting tests."""
+
     def test_positive_integer_setting(self):
         setting = appsettings.PositiveIntegerSetting()
         assert setting.value == 0
+
+
+class FloatSettingTestCase(SimpleTestCase):
+    """FloatSetting tests."""
 
     def test_float_setting(self):
         setting = appsettings.FloatSetting()
         assert setting.value == 0.0
 
+    @mock.patch.dict(os.environ, {"SETTING": "123.456"})
+    def test_float_setting_from_environ_value(self):
+        setting = appsettings.FloatSetting(name="setting")
+        setting.check()
+        assert setting.value == 123.456
+        assert type(setting.value) is float
+
+
+class PositiveFloatSettingTestCase(SimpleTestCase):
+    """PositiveFloatSetting tests."""
+
     def test_positive_float_setting(self):
         setting = appsettings.PositiveFloatSetting()
         assert setting.value == 0.0
+
+
+class IterableSettingTestCase(SimpleTestCase):
+    """IterableSetting tests."""
 
     def test_iterable_setting(self):
         setting = appsettings.IterableSetting()
         assert setting.value is None
 
+    @mock.patch.dict(os.environ, {"SETTING": "[1, 2, 3]"})
+    def test_iterable_setting_from_environ_json_value(self):
+        setting = appsettings.IterableSetting(name="setting")
+        setting.check()
+        assert setting.value == [1, 2, 3]
+
+    @mock.patch.dict(os.environ, {"SETTING": "1:2:3"})
+    def test_iterable_setting_from_environ_delimiter_value(self):
+        setting = appsettings.IterableSetting(name="setting")
+        setting.check()
+        assert setting.value == ["1", "2", "3"]
+
+    @mock.patch.dict(os.environ, {"SETTING": "1-2-3"})
+    def test_iterable_setting_from_environ_delimiter_value_with_item_type(self):
+        setting = appsettings.IterableSetting(name="setting", item_type=int, delimiter="-")
+        setting.check()
+        assert setting.value == [1, 2, 3]
+
+
+class StringSettingTestCase(SimpleTestCase):
+    """StringSetting tests."""
+
     def test_string_setting(self):
         setting = appsettings.StringSetting()
         assert setting.value == ""
+
+    @mock.patch.dict(os.environ, {"SETTING": '"json-string"'})
+    def test_string_setting_from_environ_json_value(self):
+        setting = appsettings.StringSetting(name="setting")
+        setting.check()
+        assert setting.value == "json-string"
+
+    @mock.patch.dict(os.environ, {"SETTING": "pure-string"})
+    def test_string_setting_from_environ_pure_value(self):
+        setting = appsettings.StringSetting(name="setting")
+        setting.check()
+        assert setting.value == "pure-string"
+
+
+class ListSettingTestCase(SimpleTestCase):
+    """ListSetting tests."""
 
     def test_list_setting(self):
         setting = appsettings.ListSetting()
         assert setting.value == []
 
+
+class SetSettingTestCase(SimpleTestCase):
+    """SetSetting tests."""
+
     def test_set_setting(self):
         setting = appsettings.SetSetting()
         assert setting.value == set()
+
+    @mock.patch.dict(os.environ, {"SETTING": "a:b:b:b:c"})
+    def test_set_setting_from_environ_value(self):
+        setting = appsettings.SetSetting(name="setting")
+        setting.check()
+        assert setting.value == {"a", "b", "c"}
+
+
+class TupleSettingTestCase(SimpleTestCase):
+    """TupleSetting tests."""
 
     def test_tuple_setting(self):
         setting = appsettings.TupleSetting()
         assert setting.value == ()
 
+    @mock.patch.dict(os.environ, {"SETTING": "a:b:c"})
+    def test_tuple_setting_from_environ_value(self):
+        setting = appsettings.TupleSetting(name="setting")
+        setting.check()
+        assert setting.value == ("a", "b", "c")
+
+
+class DictSettingTestCase(SimpleTestCase):
+    """DictSetting tests."""
+
     def test_dict_setting(self):
         setting = appsettings.DictSetting()
         assert setting.value == {}
+
+    @mock.patch.dict(os.environ, {"SETTING": '{"a": "A", "b": "B"}'})
+    def test_dict_setting_from_environ_json_value(self):
+        setting = appsettings.DictSetting(name="setting")
+        setting.check()
+        assert setting.value == {"a": "A", "b": "B"}
+
+    @mock.patch.dict(os.environ, {"SETTING": "a=A b=B"})
+    def test_dict_setting_from_environ_delimiter_value(self):
+        setting = appsettings.DictSetting(name="setting")
+        setting.check()
+        assert setting.value == {"a": "A", "b": "B"}
+
+    @mock.patch.dict(os.environ, {"SETTING": "a:1--b:2"})
+    def test_dict_setting_from_environ_delimiter_value_with_types(self):
+        setting = appsettings.DictSetting(
+            name="setting", outer_delimiter="--", inner_delimiter=":", key_type=str, value_type=int
+        )
+        setting.check()
+        assert setting.value == {"a": 1, "b": 2}
+
+
+class ObjectSettingTestCase(SimpleTestCase):
+    """ObjectSetting tests."""
 
     def test_object_setting(self):
         setting = appsettings.ObjectSetting(name="object")
@@ -201,9 +393,9 @@ class SettingTestCase(SimpleTestCase):
             assert setting.value is imported_object
         setting.default = imported_object
         setting.call_default = True
-        assert setting.value == "tests.test_appsettings.SettingTestCase._imported_object2"
+        assert setting.value == "tests.test_appsettings.ImportedClass._imported_object2"
         setting.transform_default = True
-        assert setting.value is self._imported_object2
+        assert setting.value is ImportedClass._imported_object2
         with override_settings(OBJECT="this_package.does_not_exist"):
             with pytest.raises(ImportError):
                 assert setting.value
@@ -214,6 +406,16 @@ class SettingTestCase(SimpleTestCase):
             assert setting.value is None
         with override_settings(OBJECT=None):
             assert setting.value is None
+
+    @mock.patch.dict(os.environ, {"SETTING": "tests.test_appsettings.imported_object"})
+    def test_object_setting_from_environ_value(self):
+        setting = appsettings.ObjectSetting(name="setting")
+        setting.check()
+        assert setting.value is imported_object
+
+
+class CallablePathSettingTestCase(SimpleTestCase):
+    """CallablePathSetting tests."""
 
     def test_callable_path_setting(self):
         setting = appsettings.CallablePathSetting(name="callable_path")
@@ -229,116 +431,9 @@ class SettingTestCase(SimpleTestCase):
             with pytest.raises(ImproperlyConfigured):
                 setting.check()
 
-    def test_nested_setting(self):
-        setting = appsettings.NestedDictSetting(settings=dict())
-        assert setting.value == {}
-        setting.transform_default = True
-        assert setting.value == {}
 
-        setting = appsettings.NestedDictSetting(
-            name="setting",
-            default={},
-            settings=dict(
-                bool1=appsettings.BooleanSetting(default=False),
-                bool2=appsettings.BooleanSetting(name="bool3", default=True),
-            ),
-        )
-        assert setting.value == {}
-
-        with override_settings(SETTING={"BOOL3": False}):
-            assert setting.value == {"bool1": False, "bool2": False}
-
-    def test_nested_list_setting(self):
-        setting = appsettings.NestedListSetting(name="setting", default=[], inner_setting=appsettings.IntegerSetting())
-        setting.check()
-        assert setting.value == []
-
-        with override_settings(SETTING=[0, 1, 2]):
-            setting.check()
-            assert setting.value == (0, 1, 2)
-        with override_settings(SETTING=[0, "1", 2]):
-            with pytest.raises(ImproperlyConfigured):
-                setting.check()
-
-        setting = appsettings.NestedListSetting(
-            name="setting",
-            default=["tests.test_appsettings.imported_object"],
-            transform_default=True,
-            inner_setting=appsettings.ObjectSetting(),
-        )
-        setting.check()
-        assert setting.value == (imported_object,)
-        with override_settings(
-            SETTING=[
-                "tests.test_appsettings.imported_object",
-                "tests.test_appsettings.SettingTestCase._imported_object2",
-            ]
-        ):
-            setting.check()
-            assert setting.value == (imported_object, self._imported_object2)
-
-    def test_nested_nested_list_setting(self):
-        setting = appsettings.NestedListSetting(
-            name="setting",
-            default=[],
-            inner_setting=appsettings.NestedListSetting(
-                name="inner", default=[], inner_setting=appsettings.IntegerSetting()
-            ),
-        )
-        setting.check()
-        assert setting.value == []
-        assert setting.inner_setting.name == "inner"
-        with override_settings(SETTING=([1, 2, 3], [4, 5])):
-            setting.check()
-            assert setting.value == ((1, 2, 3), (4, 5))
-        with override_settings(SETTING=[[1, 2, 3], ["x", 5]]):
-            with pytest.raises(ImproperlyConfigured):
-                setting.check()
-
-        setting = appsettings.NestedListSetting(
-            name="setting",
-            inner_setting=appsettings.NestedListSetting(
-                inner_setting=appsettings.NestedListSetting(inner_setting=appsettings.ObjectSetting())
-            ),
-        )
-        assert setting.inner_setting.name == "setting"
-        with override_settings(
-            SETTING=[
-                (
-                    ["tests.test_appsettings.imported_object"],
-                    ["tests.test_appsettings.SettingTestCase._imported_object2"],
-                )
-            ]
-        ):
-            setting.check()
-            assert setting.value == (((imported_object,), (self._imported_object2,)),)
-        with override_settings(
-            SETTING=[[["tests.test_appsettings.imported_object"], ["tests.test_appsettings.object_does_not_exist"]]]
-        ):
-            with pytest.raises(AttributeError):
-                assert setting.value
-
-    def test_nested_list_in_nested_dict_setting(self):
-        setting = appsettings.NestedDictSetting(
-            name="setting",
-            default={},
-            settings=dict(
-                select=appsettings.NestedListSetting(
-                    name="pick", default=[1], inner_setting=appsettings.IntegerSetting()
-                )
-            ),
-        )
-        setting.check()
-        assert setting.value == {}
-        with override_settings(SETTING={}):
-            setting.check()
-            assert setting.value == {"select": [1]}
-        with override_settings(SETTING={"PICK": [2]}):
-            setting.check()
-            assert setting.value == {"select": (2,)}
-        with override_settings(SETTING={"PICK": ["xyz"]}):
-            with pytest.raises(ImproperlyConfigured):
-                setting.check()
+class NestedDictSettingTestCase(SimpleTestCase):
+    """NestedDictSetting tests."""
 
     def test_nested_dict_setting_not_required_anything(self):
         outer_setting = appsettings.NestedDictSetting(
@@ -426,149 +521,6 @@ class SettingTestCase(SimpleTestCase):
             assert len(outer_setting.value.items()) == 1
             assert outer_setting.value.get("inner_setting") == "Value"
 
-    @mock.patch.dict(os.environ, {"PREFERENCE_SETTING": '"__ENV__"'})
-    def test_preference_of_environ_values(self):
-        setting = appsettings.Setting(name="preference_setting")
-        with override_settings(PREFERENCE_SETTING="__OVER__"):
-            setting.check()
-            assert setting.value == "__ENV__"
-
-    @mock.patch.dict(os.environ, {"SETTING": '{"key": ["v", "a", "l"]}'})
-    def test_json_from_environ_value(self):
-        setting = appsettings.Setting(name="setting")
-        setting.check()
-        assert setting.value == {"key": ["v", "a", "l"]}
-
-    @mock.patch.dict(os.environ, {"SETTING": "true"})
-    def test_json_boolean_setting_from_environ_true_value(self):
-        setting = appsettings.BooleanSetting(name="setting")
-        setting.check()
-        assert setting.value is True
-
-    @mock.patch.dict(os.environ, {"BOOL_LOWER": "true", "BOOL_UPPER": "TRUE", "BOOL_NUM": "1", "BOOL_WORD": "yes"})
-    def test_string_boolean_setting_from_environ_true_value(self):
-        bool_lower = appsettings.BooleanSetting(name="bool_lower")
-        bool_lower.check()
-        assert bool_lower.value is True
-
-        bool_upper = appsettings.BooleanSetting(name="bool_upper")
-        bool_upper.check()
-        assert bool_upper.value is True
-
-        bool_num = appsettings.BooleanSetting(name="bool_num")
-        bool_num.check()
-        assert bool_num.value is True
-
-        bool_word = appsettings.BooleanSetting(name="bool_word")
-        bool_word.check()
-        assert bool_word.value is True
-
-    @mock.patch.dict(os.environ, {"BOOL_LOWER": "false", "BOOL_UPPER": "FALSE", "BOOL_NUM": "0", "BOOL_WORD": "no"})
-    def test_string_boolean_setting_from_environ_false_value(self):
-        bool_lower = appsettings.BooleanSetting(name="bool_lower")
-        bool_lower.check()
-        assert bool_lower.value is False
-
-        bool_upper = appsettings.BooleanSetting(name="bool_upper")
-        bool_upper.check()
-        assert bool_upper.value is False
-
-        bool_num = appsettings.BooleanSetting(name="bool_num")
-        bool_num.check()
-        assert bool_num.value is False
-
-        bool_word = appsettings.BooleanSetting(name="bool_word")
-        bool_word.check()
-        assert bool_word.value is False
-
-    @mock.patch.dict(os.environ, {"BOOL_SETTING": "invalid"})
-    def test_string_boolean_setting_from_environ_invalid_value(self):
-        bool_setting = appsettings.BooleanSetting(name="bool_setting")
-        with pytest.raises(ValueError, match="Invalid boolean setting BOOL_SETTING"):
-            bool_setting.check()
-
-    @mock.patch.dict(os.environ, {"SETTING": "123"})
-    def test_integer_setting_from_environ_value(self):
-        setting = appsettings.IntegerSetting(name="setting")
-        setting.check()
-        assert setting.value == 123
-        assert type(setting.value) is int
-
-    @mock.patch.dict(os.environ, {"SETTING": "123.456"})
-    def test_float_setting_from_environ_value(self):
-        setting = appsettings.FloatSetting(name="setting")
-        setting.check()
-        assert setting.value == 123.456
-        assert type(setting.value) is float
-
-    @mock.patch.dict(os.environ, {"SETTING": "[1, 2, 3]"})
-    def test_iterable_setting_from_environ_json_value(self):
-        setting = appsettings.IterableSetting(name="setting")
-        setting.check()
-        assert setting.value == [1, 2, 3]
-
-    @mock.patch.dict(os.environ, {"SETTING": "1:2:3"})
-    def test_iterable_setting_from_environ_delimiter_value(self):
-        setting = appsettings.IterableSetting(name="setting")
-        setting.check()
-        assert setting.value == ["1", "2", "3"]
-
-    @mock.patch.dict(os.environ, {"SETTING": "1-2-3"})
-    def test_iterable_setting_from_environ_delimiter_value_with_item_type(self):
-        setting = appsettings.IterableSetting(name="setting", item_type=int, delimiter="-")
-        setting.check()
-        assert setting.value == [1, 2, 3]
-
-    @mock.patch.dict(os.environ, {"SETTING": '"json-string"'})
-    def test_string_setting_from_environ_json_value(self):
-        setting = appsettings.StringSetting(name="setting")
-        setting.check()
-        assert setting.value == "json-string"
-
-    @mock.patch.dict(os.environ, {"SETTING": "pure-string"})
-    def test_string_setting_from_environ_pure_value(self):
-        setting = appsettings.StringSetting(name="setting")
-        setting.check()
-        assert setting.value == "pure-string"
-
-    @mock.patch.dict(os.environ, {"SETTING": "a:b:b:b:c"})
-    def test_set_setting_from_environ_value(self):
-        setting = appsettings.SetSetting(name="setting")
-        setting.check()
-        assert setting.value == {"a", "b", "c"}
-
-    @mock.patch.dict(os.environ, {"SETTING": "a:b:c"})
-    def test_tuple_setting_from_environ_value(self):
-        setting = appsettings.TupleSetting(name="setting")
-        setting.check()
-        assert setting.value == ("a", "b", "c")
-
-    @mock.patch.dict(os.environ, {"SETTING": '{"a": "A", "b": "B"}'})
-    def test_dict_setting_from_environ_json_value(self):
-        setting = appsettings.DictSetting(name="setting")
-        setting.check()
-        assert setting.value == {"a": "A", "b": "B"}
-
-    @mock.patch.dict(os.environ, {"SETTING": "a=A b=B"})
-    def test_dict_setting_from_environ_delimiter_value(self):
-        setting = appsettings.DictSetting(name="setting")
-        setting.check()
-        assert setting.value == {"a": "A", "b": "B"}
-
-    @mock.patch.dict(os.environ, {"SETTING": "a:1--b:2"})
-    def test_dict_setting_from_environ_delimiter_value_with_types(self):
-        setting = appsettings.DictSetting(
-            name="setting", outer_delimiter="--", inner_delimiter=":", key_type=str, value_type=int
-        )
-        setting.check()
-        assert setting.value == {"a": 1, "b": 2}
-
-    @mock.patch.dict(os.environ, {"SETTING": "tests.test_appsettings.imported_object"})
-    def test_object_setting_from_environ_value(self):
-        setting = appsettings.ObjectSetting(name="setting")
-        setting.check()
-        assert setting.value is imported_object
-
     @mock.patch.dict(os.environ, {"SETTING": '{"A": "A", "B": "B"}'})
     def test_nested_dict_setting_from_environ_value(self):
         setting = appsettings.NestedDictSetting(
@@ -585,6 +537,125 @@ class SettingTestCase(SimpleTestCase):
         setting.check()
         assert setting.value["a"] == "A"
         assert setting.value["b"] == "B"
+
+
+class NestedSettingTestCase(SimpleTestCase):
+    """NestedSetting tests."""
+
+    def test_nested_setting(self):
+        setting = appsettings.NestedDictSetting(settings=dict())
+        assert setting.value == {}
+        setting.transform_default = True
+        assert setting.value == {}
+
+        setting = appsettings.NestedDictSetting(
+            name="setting",
+            default={},
+            settings=dict(
+                bool1=appsettings.BooleanSetting(default=False),
+                bool2=appsettings.BooleanSetting(name="bool3", default=True),
+            ),
+        )
+        assert setting.value == {}
+
+        with override_settings(SETTING={"BOOL3": False}):
+            assert setting.value == {"bool1": False, "bool2": False}
+
+
+class NestedListSetting(SimpleTestCase):
+    """NestedListSetting tests."""
+
+    def test_nested_list_setting(self):
+        setting = appsettings.NestedListSetting(name="setting", default=[], inner_setting=appsettings.IntegerSetting())
+        setting.check()
+        assert setting.value == []
+
+        with override_settings(SETTING=[0, 1, 2]):
+            setting.check()
+            assert setting.value == (0, 1, 2)
+        with override_settings(SETTING=[0, "1", 2]):
+            with pytest.raises(ImproperlyConfigured):
+                setting.check()
+
+        setting = appsettings.NestedListSetting(
+            name="setting",
+            default=["tests.test_appsettings.imported_object"],
+            transform_default=True,
+            inner_setting=appsettings.ObjectSetting(),
+        )
+        setting.check()
+        assert setting.value == (imported_object,)
+        with override_settings(
+            SETTING=[
+                "tests.test_appsettings.imported_object",
+                "tests.test_appsettings.ImportedClass._imported_object2",
+            ]
+        ):
+            setting.check()
+            assert setting.value == (imported_object, ImportedClass._imported_object2)
+
+    def test_nested_nested_list_setting(self):
+        setting = appsettings.NestedListSetting(
+            name="setting",
+            default=[],
+            inner_setting=appsettings.NestedListSetting(
+                name="inner", default=[], inner_setting=appsettings.IntegerSetting()
+            ),
+        )
+        setting.check()
+        assert setting.value == []
+        assert setting.inner_setting.name == "inner"
+        with override_settings(SETTING=([1, 2, 3], [4, 5])):
+            setting.check()
+            assert setting.value == ((1, 2, 3), (4, 5))
+        with override_settings(SETTING=[[1, 2, 3], ["x", 5]]):
+            with pytest.raises(ImproperlyConfigured):
+                setting.check()
+
+        setting = appsettings.NestedListSetting(
+            name="setting",
+            inner_setting=appsettings.NestedListSetting(
+                inner_setting=appsettings.NestedListSetting(inner_setting=appsettings.ObjectSetting())
+            ),
+        )
+        assert setting.inner_setting.name == "setting"
+        with override_settings(
+            SETTING=[
+                (
+                    ["tests.test_appsettings.imported_object"],
+                    ["tests.test_appsettings.ImportedClass._imported_object2"],
+                )
+            ]
+        ):
+            setting.check()
+            assert setting.value == (((imported_object,), (ImportedClass._imported_object2,)),)
+        with override_settings(
+            SETTING=[[["tests.test_appsettings.imported_object"], ["tests.test_appsettings.object_does_not_exist"]]]
+        ):
+            with pytest.raises(AttributeError):
+                assert setting.value
+
+    def test_nested_list_in_nested_dict_setting(self):
+        setting = appsettings.NestedDictSetting(
+            name="setting",
+            default={},
+            settings=dict(
+                select=appsettings.NestedListSetting(
+                    name="pick", default=[1], inner_setting=appsettings.IntegerSetting()
+                )
+            ),
+        )
+        setting.check()
+        assert setting.value == {}
+        with override_settings(SETTING={}):
+            setting.check()
+            assert setting.value == {"select": [1]}
+        with override_settings(SETTING={"PICK": [2]}):
+            setting.check()
+            assert setting.value == {"select": (2,)}
+        with override_settings(SETTING={"PICK": ["xyz"]}):
+            with pytest.raises(ImproperlyConfigured):
+                setting.check()
 
 
 class AppSettingsTestCase(SimpleTestCase):

--- a/tests/test_appsettings.py
+++ b/tests/test_appsettings.py
@@ -435,6 +435,25 @@ class CallablePathSettingTestCase(SimpleTestCase):
 class NestedDictSettingTestCase(SimpleTestCase):
     """NestedDictSetting tests."""
 
+    def test_nested_setting(self):
+        setting = appsettings.NestedDictSetting(settings=dict())
+        assert setting.value == {}
+        setting.transform_default = True
+        assert setting.value == {}
+
+        setting = appsettings.NestedDictSetting(
+            name="setting",
+            default={},
+            settings=dict(
+                bool1=appsettings.BooleanSetting(default=False),
+                bool2=appsettings.BooleanSetting(name="bool3", default=True),
+            ),
+        )
+        assert setting.value == {}
+
+        with override_settings(SETTING={"BOOL3": False}):
+            assert setting.value == {"bool1": False, "bool2": False}
+
     def test_nested_dict_setting_not_required_anything(self):
         outer_setting = appsettings.NestedDictSetting(
             name="outer_setting", settings=dict(inner_setting=appsettings.StringSetting(default="Default"))
@@ -539,30 +558,7 @@ class NestedDictSettingTestCase(SimpleTestCase):
         assert setting.value["b"] == "B"
 
 
-class NestedSettingTestCase(SimpleTestCase):
-    """NestedSetting tests."""
-
-    def test_nested_setting(self):
-        setting = appsettings.NestedDictSetting(settings=dict())
-        assert setting.value == {}
-        setting.transform_default = True
-        assert setting.value == {}
-
-        setting = appsettings.NestedDictSetting(
-            name="setting",
-            default={},
-            settings=dict(
-                bool1=appsettings.BooleanSetting(default=False),
-                bool2=appsettings.BooleanSetting(name="bool3", default=True),
-            ),
-        )
-        assert setting.value == {}
-
-        with override_settings(SETTING={"BOOL3": False}):
-            assert setting.value == {"bool1": False, "bool2": False}
-
-
-class NestedListSetting(SimpleTestCase):
+class NestedListSettingTestCase(SimpleTestCase):
     """NestedListSetting tests."""
 
     def test_nested_list_setting(self):


### PR DESCRIPTION
As mentioned in #81 ([in comments](https://github.com/pawamoy/django-appsettings/pull/81#discussion_r402307305)) it would be great to split the huge `SettingTestCase` into small individual test cases corresponding to individual subsettings.

Some of the test cases have like 1 or 2 tests and might have been merged to their parent settings (for example `CallablePathSettingTestCase` to `ObjectSettingTestCase`, `PositiveFloatSettingTestCase` to `FloatSettingTestCase` or merge all iterable settings together). But this way seems to be much more cleaner and nicer.