### PR TITLE
Drop typing announcement, refs #89

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Utilities',
-        'Typing :: Typed',
     ],
     keywords=[
         'django', 'app', 'settings',


### PR DESCRIPTION
We're not able to fix the settings annotations. We disable the annotations for external projects until we fix the issue.